### PR TITLE
Add a gemspec config so that rubygems will link to the exact source code repo

### DIFF
--- a/ruby/inclusive-code.gemspec
+++ b/ruby/inclusive-code.gemspec
@@ -12,6 +12,7 @@ Gem::Specification.new do |spec|
   spec.license = 'MIT'
   spec.files = Dir['{lib}/**/*.rb', 'config/default.yml', 'README.md']
   spec.require_paths = ['lib']
+  spec.metadata    = { "source_code_uri" => "https://github.com/flexport/inclusive-code" }
 
   spec.add_runtime_dependency 'activesupport', '>= 4.0'
   spec.add_runtime_dependency 'rubocop', '>= 0.70.0'


### PR DESCRIPTION
Makes it easier for folks who see this in projects to find its source