### PR TITLE
Provides support for 'allowed_files' configuration

### DIFF
--- a/inclusive_code_flagged_terms.yml
+++ b/inclusive_code_flagged_terms.yml
@@ -8,12 +8,10 @@ flagged_terms:
     suggestions:
       - allowlist
       - includelist
-    allowed: []
   "black[-_\\s]*list":
     suggestions:
       - blocklist
       - excludelist
-    allowed: []
   master:
     suggestions:
       - leader
@@ -29,63 +27,51 @@ flagged_terms:
       - follower
       - secondary
       - replica
-    allowed: []
   redline:
     suggestions:
       - priority line
       - exception
       - anomaly
-    allowed: []
   grandfathered:
     suggestions:
       - exempt
       - legacy
-    allowed: []
 
   # Ableist
   sanity check:
     suggestions:
       - check
       - validity check
-    allowed: []
   crippled:
     suggestions:
       - slowed
       - overloaded
-    allowed: []
   dummy:
     suggestions:
       - placeholder
       - mock
-    allowed: []
 
   # Gendered
   man-in-the-middle:
     suggestions:
       - person-in-the-middle
       - on-path attack
-    allowed: []
   # Wrapping pronouns with whitespace to avoid overmatching
   " her ":
     suggestions:
       - " them "
-    allowed: []
   " she ":
     suggestions:
       - " they "
-    allowed: []
   " him ":
     suggestions:
       - " them "
-    allowed: []
   " he ":
     suggestions:
       - " they "
-    allowed: []
 
   # Other
   first-class citizen:
     suggestions:
       - first-class concern
       - core concern
-    allowed: []

--- a/ruby/README.md
+++ b/ruby/README.md
@@ -19,7 +19,7 @@ Configure your own set of flagged terms following the structure of the `inclusiv
 
 Put this into your .rubocop.yml:
 
-```
+```yaml
 require:
   - inclusive-code
 
@@ -29,8 +29,75 @@ Flexport/InclusiveCode:
   DisableAutoCorrect: false
 ```
 
-You can run the cop on your entire codebase with `rubocop --only Flexport/InclusiveCode`. 
+You can run the cop on your entire codebase with `rubocop --only Flexport/InclusiveCode`.
 
 You can run the cop on a specific file with `rubocop --only Flexport/InclusiveCode file_path`.
 
 If you want to add inline `rubocop:disable` or `rubocop:todo` comments on all offenses, set `DisableAutoCorrect: true` in your .rubocop.yml, and run `rubocop --only Flexport/InclusiveCode --auto-correct --disable-uncorrectable`.
+
+## Configuration
+
+The inclusive-code gem includes an initial configuration to get your project started. You can customize this configuration to fit your needs.
+
+### Flagging harmful terms
+
+Rules are added under the key `flagged_term` as follows:
+
+```yaml
+---
+flagged_terms:
+  another_harmful_term:
+    suggestions:
+      - an_appropriate_alternative
+    allowed: []
+```
+
+### Specifying harmful terminology
+
+You can specify harmful terminology using basic keys (`another_harmful_term:`), string keys (`" his ":`), or using [regular expressions](https://rubular.com/r/HvcomHUBZ3KFCz) like `"white[-_\\s]*list":`. Please note that when specifying a regular expression, some characters (`\`) may need to be escaped.
+
+### Allowing exceptions
+
+This gem supports two ways to specify exceptions to your rules: allowing specific terms, allowing specific files.
+
+#### Allowing specific terms
+
+You might want to do this to allow for an [Industry Term Exception](../README.md#industry-term-exemption). Here's how to allow certain terms using the `allowed:` key:
+
+```yaml
+---
+flagged_terms:
+  master:
+    suggestions:
+      - main
+    allowed:
+      - master bill
+      - master air waybill
+      - master consol
+      - master shipment
+```
+
+#### Allowing specific files
+
+You might want to do this when you wish to disallow some term, but you need to allow it in certain files. Perhaps you rely on some library which requires you to configure it using some harmful terminology. Here's how to allow occurrences of a harmful term when they occur within some file using the `allowed_files:` key:
+
+```yaml
+---
+flagged_terms:
+  whitelist:
+    suggestions:
+      - main
+    allowed_files:
+      - config/initializers/some_gem_config.rb
+      - .some_gem/*
+```
+
+This will would result in allowing offenses in any files returned by `Dir.glob("{config/initializers/some_gem_config.rb,.some_gem/*}")`
+
+### Suggestions and Autocorrect
+
+In a document titled [Terminology, Power and Offensive Language](https://tools.ietf.org/id/draft-knodel-terminology-01.html), the Internet Engineering Task Force (IETF) recommends that an editor or reviewer *should* "offer alternatives for offensive terminology as an important act of correcting larger editorial issues and clarifying technical concepts."
+
+As this gem does some of the work of an editor or reviewer, it is appropriate that it should allow for communicating better alternatives when it finds harmful terminology.
+
+When using autocorrect, the first item in the suggestions array will be used as the autocorrect term.

--- a/ruby/README.md
+++ b/ruby/README.md
@@ -46,15 +46,40 @@ Rules are added under the key `flagged_term` as follows:
 ```yaml
 ---
 flagged_terms:
-  another_harmful_term:
-    suggestions:
-      - an_appropriate_alternative
-    allowed: []
+  some_harmful_term: {}
 ```
 
 ### Specifying harmful terminology
 
-You can specify harmful terminology using basic keys (`another_harmful_term:`), string keys (`" his ":`), or using [regular expressions](https://rubular.com/r/HvcomHUBZ3KFCz) like `"white[-_\\s]*list":`. Please note that when specifying a regular expression, some characters (`\`) may need to be escaped.
+You can specify harmful terminology using basic keys (`another_harmful_term:`), string keys (`" his ":`), or using [regular expressions](https://rubular.com/r/HvcomHUBZ3KFCz) like `"white[-_\\s]*list":`. Please note that when specifying a regular expression, some characters (`\`) may need to be escaped. Examples:
+
+```yaml
+---
+flagged_terms:
+  "white[-_\\s]*list": {}
+  "black[-_\\s]*list": {}
+  " him ": {}
+  master: {}
+```
+
+### Suggestions and Autocorrect
+
+In a document titled [Terminology, Power and Offensive Language](https://tools.ietf.org/id/draft-knodel-terminology-01.html), the Internet Engineering Task Force (IETF) recommends that an editor or reviewer *should* "offer alternatives for offensive terminology as an important act of correcting larger editorial issues and clarifying technical concepts."
+
+As this gem does some of the work of an editor or reviewer, it is appropriate that it should allow for communicating better alternatives when it finds harmful technology.
+
+Here's how you can offer alternative suggestions:
+
+```yaml
+---
+flagged_terms:
+  some_harmful_term:
+    suggestions:
+      - some_thoughtful_alternative
+      - some_other_thoughtful_alternative
+```
+
+When using autocorrect, the first item in the suggestions array will be used as the autocorrect term.
 
 ### Allowing exceptions
 
@@ -86,18 +111,10 @@ You might want to do this when you wish to disallow some term, but you need to a
 flagged_terms:
   whitelist:
     suggestions:
-      - main
+      - allowlist
     allowed_files:
       - config/initializers/some_gem_config.rb
       - .some_gem/*
 ```
 
-This will would result in allowing offenses in any files returned by `Dir.glob("{config/initializers/some_gem_config.rb,.some_gem/*}")`
-
-### Suggestions and Autocorrect
-
-In a document titled [Terminology, Power and Offensive Language](https://tools.ietf.org/id/draft-knodel-terminology-01.html), the Internet Engineering Task Force (IETF) recommends that an editor or reviewer *should* "offer alternatives for offensive terminology as an important act of correcting larger editorial issues and clarifying technical concepts."
-
-As this gem does some of the work of an editor or reviewer, it is appropriate that it should allow for communicating better alternatives when it finds harmful terminology.
-
-When using autocorrect, the first item in the suggestions array will be used as the autocorrect term.
+This will result in allowing offenses in any files returned by `Dir.glob("{config/initializers/some_gem_config.rb,.some_gem/*}")`

--- a/ruby/inclusive-code.gemspec
+++ b/ruby/inclusive-code.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 $LOAD_PATH.unshift File.expand_path('lib', __dir__)
 require_relative 'lib/rubocop/inclusive_code/version'
 
@@ -12,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.license = 'MIT'
   spec.files = Dir['{lib}/**/*.rb', 'config/default.yml', 'README.md']
   spec.require_paths = ['lib']
-  spec.metadata    = { "source_code_uri" => "https://github.com/flexport/inclusive-code" }
+  spec.metadata = { 'source_code_uri' => 'https://github.com/flexport/inclusive-code' }
 
   spec.add_runtime_dependency 'activesupport', '>= 4.0'
   spec.add_runtime_dependency 'rubocop', '>= 0.70.0'

--- a/ruby/lib/rubocop/cop/inclusive_code.rb
+++ b/ruby/lib/rubocop/cop/inclusive_code.rb
@@ -27,7 +27,8 @@ module RuboCop
 
         SEVERITY = 'warning'
 
-        MSG = '🚫 Use of non_inclusive word: `%<non_inclusive_word>s`. Consider using these suggested alternatives: `%<suggestions>s`.'
+        FLAG_ONLY_MSG = '🚫 Use of non_inclusive word: `%<non_inclusive_word>s`.'
+        FULL_FLAG_MSG = "#{FLAG_ONLY_MSG} Consider using these suggested alternatives: `%<suggestions>s`."
 
         def initialize(config = nil, options = nil, source_file = nil)
           super(config, options)
@@ -142,7 +143,7 @@ module RuboCop
         end
 
         def get_allowed_string(non_inclusive_word)
-          allowed = @non_inclusive_words_alternatives_hash[non_inclusive_word]['allowed']
+          allowed = @non_inclusive_words_alternatives_hash[non_inclusive_word].fetch('allowed') { [] }
           snake_case = allowed.map { |e| e.tr(' ', '_').underscore }
           pascal_case = snake_case.map(&:camelize)
           (allowed + snake_case + pascal_case).join('|')
@@ -158,11 +159,12 @@ module RuboCop
 
         def create_message(non_inclusive_word)
           correction = correction_for_word(non_inclusive_word)
+          suggestions = correction.fetch('suggestions') { [] }.join(', ')
 
           format(
-            MSG,
+            suggestions.present? ? FULL_FLAG_MSG : FLAG_ONLY_MSG,
             non_inclusive_word: non_inclusive_word,
-            suggestions: correction.fetch('suggestions') { [] }.join(', ')
+            suggestions: suggestions
           )
         end
       end

--- a/ruby/spec/inclusive_code/cop/inclusive_code_spec.rb
+++ b/ruby/spec/inclusive_code/cop/inclusive_code_spec.rb
@@ -116,8 +116,7 @@ RSpec.describe RuboCop::Cop::Flexport::InclusiveCode do
         described_class.new(nil, nil, flagged_terms)
       end
 
-      it 'can ignore offenses within the path of an allowed file while detecting the'\
-        'same offenses in the path of another file' do
+      it 'ignores filename offenses in an allowed file but does not ignore them in another file' do
         source = <<~RUBY
           puts "Hooray for inclusion!"
           ^ #{format(
@@ -127,11 +126,11 @@ RSpec.describe RuboCop::Cop::Flexport::InclusiveCode do
           )}
         RUBY
 
-        expect_offense(source, 'lib/rubocop/inclusive_code/version.rb')
         expect_no_offenses(source.lines.first, 'lib/rubocop/cop/inclusive_code.rb')
+        expect_offense(source, 'lib/rubocop/inclusive_code/version.rb')
       end
 
-      it 'can ignore offenses in one file while detecting other offenses in the same file' do
+      it 'allows offenses in an allowed file while detecting other offenses in the same file' do
         source = <<~RUBY
           puts "rubocop"
           puts "other_offensive_term"
@@ -142,20 +141,6 @@ RSpec.describe RuboCop::Cop::Flexport::InclusiveCode do
                 )}
         RUBY
         expect_offense(source, 'README.md')
-      end
-
-      it 'does not detect offenses in an allowed filename' do
-        source = <<~RUBY
-          puts "rubocop"
-                ^^^^^^^ #{format(
-                  msg,
-                  non_inclusive_word: 'rubocop',
-                  suggestions: 'ruby_enforcement_service'
-                )}
-        RUBY
-        expect_offense(source, 'inclusive-code.gemspec')
-
-        expect_no_offenses(source.lines.first, 'README.md')
       end
     end
 


### PR DESCRIPTION
Provides support for 'allowed_files' configuration
  - As an alternative to allowing certain incantations of offensive terms,
it may be desirable to limit the occurrence of some certain term to
specific files only.
  - Use case for consideration: A project relies on some library. The
library requires a configuration file which utilizes an offensive
term. The project developers wish to disallow the offensive term but
also wish to make an exception for the aforementioned library's
configuration file.

Extra:
- This commit addresses rubocop offenses (most, not all)
- This commit fixes a previously undetected bug, where inclusive-code
  would fail to find offenses within filenames if the flagged terms
  configuration specified zero allowed patterns