### PR TITLE
Does not flag allowed terms when those terms are not starting with the non-inclusive term

### DIFF
--- a/ruby/lib/rubocop/cop/inclusive_code.rb
+++ b/ruby/lib/rubocop/cop/inclusive_code.rb
@@ -63,11 +63,10 @@ module RuboCop
 
             non_inclusive_words_for_current_file.each do |non_inclusive_word|
               allowed = @allowed_terms[non_inclusive_word]
-              scan_regex = if allowed.blank?
-                             /(?=#{non_inclusive_word})/i
-                           else
-                             /(?=#{non_inclusive_word})(?!(#{@allowed_terms[non_inclusive_word]}))/i
-                           end
+              scan_regex = /(?=#{non_inclusive_word})/i
+              if allowed.present?
+                line = line.gsub(/(#{allowed})/i){ |match| '*' * match.size }
+              end
               locations = line.enum_for(
                 :scan,
                 scan_regex

--- a/ruby/lib/rubocop/cop/inclusive_code.rb
+++ b/ruby/lib/rubocop/cop/inclusive_code.rb
@@ -30,6 +30,8 @@ module RuboCop
         FLAG_ONLY_MSG = '🚫 Use of non_inclusive word: `%<non_inclusive_word>s`.'
         FULL_FLAG_MSG = "#{FLAG_ONLY_MSG} Consider using these suggested alternatives: `%<suggestions>s`."
 
+        ALLOWED_TERM_MASK_CHAR = '*'.freeze
+
         def initialize(config = nil, options = nil, source_file = nil)
           super(config, options)
 
@@ -65,7 +67,7 @@ module RuboCop
               allowed = @allowed_terms[non_inclusive_word]
               scan_regex = /(?=#{non_inclusive_word})/i
               if allowed.present?
-                line = line.gsub(/(#{allowed})/i){ |match| '*' * match.size }
+                line = line.gsub(/(#{allowed})/i){ |match| ALLOWED_TERM_MASK_CHAR * match.size }
               end
               locations = line.enum_for(
                 :scan,

--- a/ruby/spec/inclusive_code/cop/inclusive_code_spec.rb
+++ b/ruby/spec/inclusive_code/cop/inclusive_code_spec.rb
@@ -254,7 +254,7 @@ RSpec.describe RuboCop::Cop::Flexport::InclusiveCode do
       end
     end
 
-    context 'and the allowed term does not start with the non-inclusive language' do
+    context 'when the flagged term is not at the start of the allowed term' do
       let(:source) do
         <<~RUBY
             puts "the allowed some_euphemism"

--- a/ruby/spec/inclusive_code/cop/inclusive_code_spec.rb
+++ b/ruby/spec/inclusive_code/cop/inclusive_code_spec.rb
@@ -253,6 +253,28 @@ RSpec.describe RuboCop::Cop::Flexport::InclusiveCode do
         end
       end
     end
+
+    context 'and the allowed term does not start with the non-inclusive language' do
+      let(:source) do
+        <<~RUBY
+            puts "the allowed some_euphemism"
+        RUBY
+      end
+
+      subject(:cop) do
+        described_class.new(nil, nil, {
+          'flagged_terms' => {
+            'some_euphemism' => {
+              'allowed' => ['allowed some_euphemism']
+            }
+          }
+        })
+      end
+
+      it 'does not add offenses' do
+        expect_no_offenses(source)
+      end
+    end
   end
 
   describe '#autocorrect' do


### PR DESCRIPTION
The allowed term that did not start with the non-inclusive term was added as an offense.