### PR TITLE
add required require for active support

### DIFF
--- a/ruby/lib/rubocop/cop/inclusive_code.rb
+++ b/ruby/lib/rubocop/cop/inclusive_code.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'active_support'
 require 'active_support/core_ext/string'
 
 module RuboCop


### PR DESCRIPTION
```
Failure/Error: require 'active_support/core_ext/string'

NameError:
  uninitialized constant ActiveSupport::XmlMini::IsolatedExecutionState

          IsolatedExecutionState[:xml_mini_backend]
          ^^^^^^^^^^^^^^^^^^^^^^
```

tests were failing